### PR TITLE
Upgrade C# example to .NET 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ For more information on how to setup ShiftLeft CORE on GitHub Actions see [the d
 
 | Application Name |Technology, architecture | Framework/Version |
 |------------------|-------------------------|-----------------|
-| netcoreWebapi | WebAPI, REST | .NET Core 2.0 |
+| netcoreWebapi | WebAPI, REST | .NET 5.0 |

--- a/netcoreWebapi/netcoreWebapi.csproj
+++ b/netcoreWebapi/netcoreWebapi.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>6</LangVersion>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating target framework to demonstrate the ability to analyze .NET 5.0
apps, even if the app itself doesn't use latest stuff.